### PR TITLE
Use bash instead of sh, which fail in some systems

### DIFF
--- a/unlock.sh
+++ b/unlock.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/bin/bash
 #
 # Android pattern unlock
 # Author: Matt Wilson


### PR DESCRIPTION
In Ubuntu 15.10:

```
    ls -lah /bin/sh
    lrwxrwxrwx 1 root root 4 Dez 21 13:59 /bin/sh -> dash
```

which doesn't recognice the array syntax of bash
